### PR TITLE
Add some casts to fix some c_char inconsistencies

### DIFF
--- a/src/glesv2.rs
+++ b/src/glesv2.rs
@@ -539,7 +539,7 @@ pub fn bind_attrib_location(program: GLuint, index: GLuint, name: &str) {
     unsafe {
         let c_str = CString::new(name).unwrap();
 
-        ffi::glBindAttribLocation(program, index, c_str.as_ptr())
+        ffi::glBindAttribLocation(program, index, c_str.as_ptr() as *const c_char)
     }
 }
 
@@ -951,7 +951,7 @@ pub fn get_attrib_location(program: GLuint, name: &str) -> GLint {
     unsafe {
         let c_str = CString::new(name).unwrap();
 
-        ffi::glGetAttribLocation(program, c_str.as_ptr())
+        ffi::glGetAttribLocation(program, c_str.as_ptr() as *const c_char)
     }
 }
 
@@ -1118,7 +1118,7 @@ pub fn get_string(name: GLenum) -> Option<String> {
         let c_str = ffi::glGetString(name);
 
         if !c_str.is_null() {
-            match from_utf8(CStr::from_ptr(c_str as *const i8).to_bytes()) {
+            match from_utf8(CStr::from_ptr(c_str).to_bytes()) {
                 Ok(s)  => Some(s.to_string()),
                 Err(_) => None
             }
@@ -1597,7 +1597,7 @@ pub fn vertex_attrib_pointer<T>(index: GLuint, size: GLint, type_: GLenum,
         if buffer.len() == 0 {
             ffi::glVertexAttribPointer(index, size, type_,
                                        normalized as GLboolean,
-                                       stride, &0 as *const GLvoid)
+                                       stride, &0 as *const i32 as *const GLvoid)
         } else {
             ffi::glVertexAttribPointer(index, size, type_,
                                        normalized as GLboolean,


### PR DESCRIPTION
Building this crate with `--target=arm-unknown-linux-gnueabihf` on Rust 1.17
I hit some errors like:
```
error[E0308]: mismatched types
    --> src/glesv2.rs:1121:44
     |
1121 |             match from_utf8(CStr::from_ptr(c_str as *const c_char).to_bytes()) {
     |                                            ^^^^^^^^^^^^^^^^^^^^^^ expected u8, found i8
```

Apparently `c_char` is `i8` here. Adding a few casts fixes the issue.
There was also one other compile error that I hit compiling for arm or
natively for x86_64 Linux, which another cast fixed.